### PR TITLE
Improve defaults to allow for shorter config in pom

### DIFF
--- a/src/main/java/io/vlingo/maven/schemata/PushSchemataMojo.java
+++ b/src/main/java/io/vlingo/maven/schemata/PushSchemataMojo.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -122,7 +121,7 @@ public class PushSchemataMojo extends AbstractMojo {
         if (HttpResult == HttpURLConnection.HTTP_CREATED) {
             logger.info("Successfully pushed {}", schemaVersionUrl);
         } else {
-            try(BufferedReader br = new BufferedReader(
+            try (BufferedReader br = new BufferedReader(
                     new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
                 StringBuilder response = new StringBuilder();
                 String responseLine = null;

--- a/src/main/java/io/vlingo/maven/schemata/Schema.java
+++ b/src/main/java/io/vlingo/maven/schemata/Schema.java
@@ -1,12 +1,17 @@
 package io.vlingo.maven.schemata;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class Schema {
+    private final io.vlingo.actors.Logger logger = io.vlingo.actors.Logger.basicLogger();
+
     @Parameter(property = "src")
-    private File src;
+    private String src;
 
     @Parameter(property = "ref", required = true)
     private String ref;
@@ -14,11 +19,24 @@ public class Schema {
     @Parameter(property = "previousVersion")
     private String previousVersion;
 
-    public File getSrc() {
-        return src;
+    public Path getSrc() throws MojoExecutionException {
+        if (src != null) {
+            return Paths.get(src);
+        }
+
+        // default to schema name from reference
+        logger.debug("No explicit source file given, defaulting to <schemata srcDirectory/schema name from ref>.vss");
+        String[] refParts = ref.split(":");
+        if (refParts.length != 5) {
+            throw new MojoExecutionException(
+                    "Invalid schema reference. Should be <org>:<unit>:<context namespace>:<schema name>:<version>");
+        }
+        String fileName = refParts[3] + ".vss";
+        logger.info("Setting source to {} for {}", fileName, ref);
+        return Paths.get(fileName);
     }
 
-    public void setSrc(File src) {
+    public void setSrc(String src) {
         this.src = src;
     }
 

--- a/src/main/java/io/vlingo/maven/schemata/Schema.java
+++ b/src/main/java/io/vlingo/maven/schemata/Schema.java
@@ -3,7 +3,6 @@ package io.vlingo.maven.schemata;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 


### PR DESCRIPTION
* adds `srcDirectory` to push mojo config (default `src/main/vlingo/schemata`)
* make `schemata.schema.src` optional, default to `${srcDirectory}/<Schema parsed from reference>`

We can use shorter configs now as discussed in https://github.com/vlingo/vlingo-build-plugins-test/pull/1

```
<configuration>
  <srcDirectory>${vlingo.schemata.srcDir}</srcDirectory>
    <schemataService>
    <url>${vlingo.schemata.serviceUrl}</url>
    <clientOrganization>${vlingo.schemata.organization}</clientOrganization>
    <clientUnit>${vlingo.schemata.unit}</clientUnit>
  </schemataService>
  <schemata>
	<!-- using defaults -->
    <schema>
      <ref>Vlingo:schemata:io.vlingo.schemata:SchemaPublished:0.0.1</ref>
    </schema>
    
    <!-- being explicit -->
    <schema>
      <ref>Vlingo:schemata:io.vlingo.schemata:SchemaDefined:0.0.1</ref>
      <src>LookMaDifferentName.vss</src>
    </schema>
  </schemata>
</configuration>
```
