### PR TITLE
Native image requirements builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/vlingo/maven/codegen/ActorProxyGenerator.java
+++ b/src/main/java/io/vlingo/maven/codegen/ActorProxyGenerator.java
@@ -12,11 +12,12 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import io.vlingo.actors.ProxyGenerator;
+import org.apache.maven.plugins.annotations.Parameter;
 
 @Mojo(name="actorProxyGen")
 public class ActorProxyGenerator extends AbstractMojo {
 
-  @org.apache.maven.plugins.annotations.Parameter(required=true)
+  @Parameter(required=true)
   private String[] actorProtocols;
   private final io.vlingo.actors.Logger logger;
 

--- a/src/main/java/io/vlingo/maven/codegen/NativeActorProxyGenerator.java
+++ b/src/main/java/io/vlingo/maven/codegen/NativeActorProxyGenerator.java
@@ -1,0 +1,75 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.maven.codegen;
+
+import io.vlingo.actors.ProxyGenerator;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toSet;
+
+@Mojo(name="nativeActorProxyGen", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+public class NativeActorProxyGenerator extends AbstractMojo {
+  private static final Path REFLECTION_JSON = new File("target/classes/reflection.json").toPath();
+
+  @org.apache.maven.plugins.annotations.Parameter(required=true)
+  private String sourceRoot;
+  @org.apache.maven.plugins.annotations.Parameter(defaultValue = "[]")
+  private String[] additionalProtocols;
+
+  private final io.vlingo.actors.Logger logger;
+
+  public NativeActorProxyGenerator() {
+    this.logger = io.vlingo.actors.Logger.basicLogger();
+    logger.info("vlingo/maven: Native actor proxy generator loaded.");
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    final ProtocolScanner scanner = new ProtocolScanner(new File(sourceRoot));
+    final Set<String> protocolsAndProxies = new HashSet<>(scanner.scan());
+    protocolsAndProxies.addAll(Arrays.asList(additionalProtocols));
+
+    final ProxyGenerator proxyGenerator = newGenerator();
+    final NativeImageReflectionConfigurationGenerator reflectionConfigurationGenerator = new NativeImageReflectionConfigurationGenerator(protocolsAndProxies);
+    final Set<String> actorProtocols = protocolsAndProxies.stream().filter(className -> !className.endsWith("__Proxy")).collect(toSet());
+
+    try {
+      actorProtocols.forEach(proxyGenerator::generateFor);
+      Files.write(REFLECTION_JSON, reflectionConfigurationGenerator.generate().getBytes());
+    } catch (Exception e) {
+      final String message = "Proxy generator failed because: " + e.getMessage();
+      logger.error(message, e);
+      e.printStackTrace();
+      throw new MojoExecutionException(message, e);
+    }
+  }
+
+  private ProxyGenerator newGenerator() throws MojoExecutionException {
+    try {
+      return ProxyGenerator.forMain(true, logger);
+    } catch (Exception e) {
+      final String message = "Proxy generator failed because: " + e.getMessage();
+      logger.error(message, e);
+      e.printStackTrace();
+      throw new MojoExecutionException(message, e);
+    }
+  }
+}

--- a/src/main/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGenerator.java
+++ b/src/main/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGenerator.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.maven.codegen;
 
 import java.util.Set;

--- a/src/main/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGenerator.java
+++ b/src/main/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGenerator.java
@@ -1,0 +1,29 @@
+package io.vlingo.maven.codegen;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a reflection.json as a String for the provided list of classes.
+ *
+ * @since 1.0.0
+ */
+public class NativeImageReflectionConfigurationGenerator {
+    private static final String START_FILE = "[\n";
+    private static final String START_CONFIG_LINE = "  {\n";
+    private static final String CONFIG_LINE = "    \"name\" : \"%%CLASS_NAME%%\", \"allDeclaredConstructors\" : true, \"allPublicConstructors\" : true, \"allDeclaredMethods\" : true, \"allPublicMethods\" : true, \"allDeclaredClasses\" : true, \"allPublicClasses\" : true\n";
+    private static final String END_CONFIG_LINE = "  }";
+    private static final String END_FILE = "\n]";
+
+    private final Set<String> classNames;
+
+    public NativeImageReflectionConfigurationGenerator(Set<String> classNames) {
+        this.classNames = classNames;
+    }
+
+    public String generate() {
+        return START_FILE +
+                classNames.stream().map(name -> CONFIG_LINE.replaceAll("%%CLASS_NAME%%", name)).map(line -> START_CONFIG_LINE + line + END_CONFIG_LINE).collect(Collectors.joining(",\n")) +
+                END_FILE;
+    }
+}

--- a/src/main/java/io/vlingo/maven/codegen/ProtocolScanner.java
+++ b/src/main/java/io/vlingo/maven/codegen/ProtocolScanner.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.maven.codegen;
 
 import java.io.File;

--- a/src/main/java/io/vlingo/maven/codegen/ProtocolScanner.java
+++ b/src/main/java/io/vlingo/maven/codegen/ProtocolScanner.java
@@ -1,0 +1,115 @@
+package io.vlingo.maven.codegen;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * Iterates over a source directory with Java classes and finds out which interfaces are meant to be Proxy interfaces.
+ * It tries to detect cases where .actorFor is used to instantiate actors and resolves imports to detect the full qualified
+ * name of the proxy class.
+ *
+ * @since 1.0.0
+ */
+public class ProtocolScanner {
+    private final File directory;
+
+    public ProtocolScanner(final File directory) {
+        this.directory = directory;
+    }
+
+    /**
+     * @return the list of all interfaces and proxies that need to be loaded during runtime
+     */
+    public Set<String> scan() {
+        return scanDirectory(directory).collect(toSet());
+    }
+
+    private Stream<String> scanDirectory(File directory) {
+        final File[] values = directory.listFiles();
+        if (values == null) {
+            return Stream.empty();
+        }
+
+        return Stream.of(values).flatMap(file -> {
+            if (file.isDirectory()) {
+                return scanDirectory(file);
+            } else {
+                return scanFile(file);
+            }
+        });
+    }
+
+    private Stream<String> scanFile(File file) {
+        if (!file.getName().endsWith(".java")) {
+            return Stream.empty();
+        }
+
+        String javaCode = load(file);
+        String packageName = packageName(javaCode);
+        Map<String, String> imports = importsOf(javaCode);
+        Set<String> proxies = usagesAsProxies(javaCode);
+
+        return proxies.stream()
+                .map(protocol -> imports.getOrDefault(protocol, fromPackageName(packageName, protocol)))
+                .flatMap(protocol -> Stream.of(protocol, protocol + "__Proxy"));
+    }
+
+    private String packageName(String javaCode) {
+        return extractFromWrappingTokens(javaCode, "package", ";");
+    }
+
+    private Map<String, String> importsOf(String javaCode) {
+        return Arrays.stream(javaCode.split("\n"))
+                .map(String::trim)
+                .filter(line -> line.startsWith("import") && line.endsWith(";"))
+                .map(line -> extractFromWrappingTokens(javaCode, "import", ";"))
+                .collect(groupingBy(javaImport -> javaImport.substring(javaImport.lastIndexOf(".") + 1)))
+                .entrySet()
+                .stream()
+                .collect(toMap(e -> e.getKey(), e -> e.getValue().get(0)));
+    }
+
+    private Set<String> usagesAsProxies(String javaCode) {
+        return Arrays.stream(javaCode.split("\n"))
+                .map(String::trim)
+                .filter(line -> line.contains(".actorFor"))
+                .map(line -> extractFromWrappingTokens(javaCode, ".actorFor(", ".class"))
+                .collect(toSet());
+    }
+
+    private String load(File file) {
+        try {
+            return new String(Files.readAllBytes(file.toPath()));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String extractFromWrappingTokens(String javaCode, String startToken, String endToken) {
+        int packageStart = javaCode.indexOf(startToken);
+        if (packageStart == -1) {
+            return "";
+        }
+
+        packageStart += startToken.length();
+        int packageEnd = javaCode.indexOf(endToken, packageStart);
+        if (packageEnd == -1) {
+            return "";
+        }
+
+        return javaCode.substring(packageStart, packageEnd).trim();
+    }
+
+    private String fromPackageName(String packageName, String proxy) {
+        if (packageName.equals("")) {
+            return proxy;
+        } else {
+            return packageName + "." + proxy;
+        }
+    }
+}

--- a/src/test/java/io/vlingo/maven/codegen/Data.java
+++ b/src/test/java/io/vlingo/maven/codegen/Data.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.maven.codegen;
 
 import java.util.LinkedHashSet;

--- a/src/test/java/io/vlingo/maven/codegen/Data.java
+++ b/src/test/java/io/vlingo/maven/codegen/Data.java
@@ -1,0 +1,14 @@
+package io.vlingo.maven.codegen;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class Data {
+    public static final Set<String> FAKE_CLASSES = new LinkedHashSet<>();
+    static {
+        FAKE_CLASSES.add("io.vlingo.nativeexample.ping.Ping");
+        FAKE_CLASSES.add("io.vlingo.nativeexample.ping.Ping__Proxy");
+        FAKE_CLASSES.add("io.vlingo.nativeexample.pong.Pong");
+        FAKE_CLASSES.add("io.vlingo.nativeexample.pong.Pong__Proxy");
+    }
+}

--- a/src/test/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGeneratorTest.java
+++ b/src/test/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGeneratorTest.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.maven.codegen;
 
 import org.junit.Test;

--- a/src/test/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGeneratorTest.java
+++ b/src/test/java/io/vlingo/maven/codegen/NativeImageReflectionConfigurationGeneratorTest.java
@@ -1,0 +1,19 @@
+package io.vlingo.maven.codegen;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class NativeImageReflectionConfigurationGeneratorTest {
+    @Test
+    public void shouldGenerateTheExpectedReflectionJson() throws Exception {
+        String expected = new String(Files.readAllBytes(Paths.get(getClass().getResource("/reflection-test.json").toURI()))).replaceAll(System.lineSeparator(), "\n");
+        NativeImageReflectionConfigurationGenerator generator = new NativeImageReflectionConfigurationGenerator(Data.FAKE_CLASSES);
+
+        String result = generator.generate();
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/io/vlingo/maven/codegen/ProtocolScannerTest.java
+++ b/src/test/java/io/vlingo/maven/codegen/ProtocolScannerTest.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.maven.codegen;
 
 import org.junit.Test;

--- a/src/test/java/io/vlingo/maven/codegen/ProtocolScannerTest.java
+++ b/src/test/java/io/vlingo/maven/codegen/ProtocolScannerTest.java
@@ -1,0 +1,19 @@
+package io.vlingo.maven.codegen;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProtocolScannerTest {
+    @Test
+    public void shouldFindProxiesAndProtocolsFromADirectory() {
+        ProtocolScanner scanner = new ProtocolScanner(new File("src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory"));
+        Set<String> reflectionClasses = scanner.scan();
+
+        assertEquals(Data.FAKE_CLASSES, reflectionClasses);
+
+    }
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/Application.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/Application.java
@@ -1,0 +1,19 @@
+package io.vlingo.nativeexample;
+
+import io.vlingo.nativeexample.ping.Ping;
+import io.vlingo.nativeexample.ping.PingActor;
+import io.vlingo.nativeexample.pong.Pong;
+import io.vlingo.actors.World;
+import io.vlingo.nativeexample.pong.PongActor;
+
+public class Application {
+    public static void main(String[] args) throws InterruptedException {
+        World world = World.startWithDefaults("ping-pong-native");
+        Ping ping = PingActor.instanceOn(world.stage());
+        Pong pong = PongActor.instanceOn(world.stage());
+
+        ping.ping(pong);
+        Thread.sleep(1000);
+        world.terminate();
+    }
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/Application.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/Application.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.nativeexample;
 
 import io.vlingo.nativeexample.ping.Ping;

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/Ping.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/Ping.java
@@ -1,3 +1,10 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
 package io.vlingo.nativeexample.ping;
 
 import io.vlingo.nativeexample.pong.Pong;

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/Ping.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/Ping.java
@@ -1,0 +1,7 @@
+package io.vlingo.nativeexample.ping;
+
+import io.vlingo.nativeexample.pong.Pong;
+
+public interface Ping {
+    void ping(final Pong pong);
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/PingActor.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/PingActor.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.nativeexample.ping;
 
 import io.vlingo.actors.Stage;

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/PingActor.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/ping/PingActor.java
@@ -1,0 +1,29 @@
+package io.vlingo.nativeexample.ping;
+
+import io.vlingo.actors.Stage;
+import io.vlingo.nativeexample.pong.Pong;
+import io.vlingo.actors.Actor;
+
+public class PingActor extends Actor implements Ping {
+    private int times;
+    private Ping self;
+
+    public PingActor() {
+        this.times = 0;
+        this.self = selfAs(Ping.class);
+    }
+
+    public static Ping instanceOn(final Stage stage) {
+        return stage.actorFor(Ping.class, PingActor.class, PingActor::new);
+    }
+
+    public void ping(Pong pong) {
+        System.out.println("Ping");
+        if (this.times > 10) {
+            this.stop();
+        } else {
+            this.times++;
+            pong.pong(self);
+        }
+    }
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/Pong.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/Pong.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.nativeexample.pong;
 
 import io.vlingo.nativeexample.ping.Ping;

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/Pong.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/Pong.java
@@ -1,0 +1,7 @@
+package io.vlingo.nativeexample.pong;
+
+import io.vlingo.nativeexample.ping.Ping;
+
+public interface Pong {
+    void pong(final Ping ping);
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/PongActor.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/PongActor.java
@@ -1,0 +1,29 @@
+package io.vlingo.nativeexample.pong;
+
+import io.vlingo.actors.Stage;
+import io.vlingo.nativeexample.ping.Ping;
+import io.vlingo.actors.Actor;
+
+public class PongActor extends Actor implements Pong {
+    private int times;
+    private Pong self;
+
+    public PongActor() {
+        this.times = 0;
+        this.self = selfAs(Pong.class);
+    }
+
+    public static Pong instanceOn(final Stage stage) {
+        return stage.actorFor(Pong.class, PongActor.class, PongActor::new);
+    }
+
+    public void pong(final Ping ping) {
+        System.out.println("Pong");
+        if (this.times > 10) {
+            this.stop();
+        } else {
+            this.times++;
+            ping.ping(self);
+        }
+    }
+}

--- a/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/PongActor.java
+++ b/src/test/resources/ProxyScannerTest/shouldFindProxiesAndProtocolsFromADirectory/java/io/vlingo/nativeexample/pong/PongActor.java
@@ -1,3 +1,9 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.nativeexample.pong;
 
 import io.vlingo.actors.Stage;

--- a/src/test/resources/reflection-test.json
+++ b/src/test/resources/reflection-test.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name" : "io.vlingo.nativeexample.ping.Ping", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredMethods" : true, "allPublicMethods" : true, "allDeclaredClasses" : true, "allPublicClasses" : true
+  },
+  {
+    "name" : "io.vlingo.nativeexample.ping.Ping__Proxy", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredMethods" : true, "allPublicMethods" : true, "allDeclaredClasses" : true, "allPublicClasses" : true
+  },
+  {
+    "name" : "io.vlingo.nativeexample.pong.Pong", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredMethods" : true, "allPublicMethods" : true, "allDeclaredClasses" : true, "allPublicClasses" : true
+  },
+  {
+    "name" : "io.vlingo.nativeexample.pong.Pong__Proxy", "allDeclaredConstructors" : true, "allPublicConstructors" : true, "allDeclaredMethods" : true, "allPublicMethods" : true, "allDeclaredClasses" : true, "allPublicClasses" : true
+  }
+]


### PR DESCRIPTION
Adds a new mojo to the maven project that:

* Detects Protocol interfaces and generates proxies accordingly for most common scenarios.
* Generates a reflection.json and bundles it as a resource.
* Adds all classes from libraries that are specified in the vlingo-reflection file in the root of the resources directory. You can see an example in the following PR file: https://github.com/vlingo/vlingo-actors/blob/d7b804ee7797ea8905d96b96173059d3cca24cde/src/main/resources/vlingo-reflection

New Mojo name: nativeActorProxyGen

**[Optional]** Parameter: sourceRoot
_Default_: src/main/java

Path with the source code


**[Optional]** Parameter: additionalProtocols
_Default_: EMPTY

List with other protocols that need to be imported into the reflection.json. Example:

```xml
<additionalProtocols>
  <param>io.vlingo.actors.plugin.supervision.DefaultSupervisorOverride</param>
  <param>io.vlingo.actors.CompletesEventually__Proxy</param>
  <param>io.vlingo.actors.Logger__Proxy</param>
  <param>io.vlingo.actors.DirectoryScanner</param>
  <param>io.vlingo.actors.DirectoryScanner__Proxy</param>
</additionalProtocols>
```